### PR TITLE
import-all() support git submodule and add drop-all() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ usage: git rstash push <stash> [<remote>]'
    or: git rstash drop <stash> [<remote>]'
    or: git rstash import <SHA>'
    or: git rstash push-all [<remote>]'
+   or: git rstash drop-all [<remote>]'
    or: git rstash import-all'
 ```
 

--- a/git-rstash
+++ b/git-rstash
@@ -6,6 +6,7 @@ function usage() {
   echo '   or: git rstash drop <stash> [<remote>]'
   echo '   or: git rstash import <SHA>'
   echo '   or: git rstash push-all [<remote>]'
+  echo '   or: git rstash drop-all [<remote>]'
   echo '   or: git rstash import-all'
 }
 
@@ -84,6 +85,16 @@ function push-all() {
   done
 }
 
+function drop-all() {
+  remote=origin
+  [ -z "$1" ] || remote="$1"
+
+  for i in $(seq 0 $(expr $(git rev-list --walk-reflogs --count stash) - 1))
+  do
+    drop $i "$remote"
+  done
+}
+
 function import-all() {
   # use git show-ref instead of check the existence of directory .git/refs/stashes,
   # because in the submodule case, the path of refs was located at .git/modules/<sumodule_name>/refs
@@ -100,7 +111,7 @@ function import-all() {
 }
 
 case "$1" in
-  push|push-all|fetch|import|import-all)
+  push|push-all|fetch|import|import-all|drop-all)
     "$@"
     ;;
   drop|remove|delete)

--- a/git-rstash
+++ b/git-rstash
@@ -51,12 +51,18 @@ function import() {
     SHA="$1"
   fi
 
-  # Start at 1 because Git won't save if duplicate of stash 0.
-  for i in $(seq 1 $(expr $(git rev-list --walk-reflogs --count stash) - 1))
-  do
-    # If commit matches existing stash, abort early.
-    diff <(git rev-parse stash@{$i}) <(git rev-parse $SHA) >/dev/null && return 0
-  done
+  # check if refs/stash already exist. If not, it is the first stash commit,
+  # just do the first stash commit. If yes, get the total stash count and
+  # check if current SHA match the existing stash.
+  if [ -n "$(git show-ref | grep -e stash$)" ]
+  then
+    # Start at 1 because Git won't save if duplicate of stash 0.
+    for i in $(seq 1 $(expr $(git rev-list --walk-reflogs --count stash) - 1))
+    do
+      # If commit matches existing stash, abort early.
+      diff <(git rev-parse stash@{$i}) <(git rev-parse $SHA) >/dev/null && return 0
+    done
+  fi
 
   git stash store --message "$(git show --no-patch --format=format:%s $SHA)" $SHA
 }

--- a/git-rstash
+++ b/git-rstash
@@ -72,12 +72,15 @@ function push-all() {
 }
 
 function import-all() {
-  if [ ! -d .git/refs/stashes ]
+  # use git show-ref instead of check the existence of directory .git/refs/stashes,
+  # because in the submodule case, the path of refs was located at .git/modules/<sumodule_name>/refs
+  stashes=$(git show-ref | grep stashes | awk {'print $2'} | awk -F "/" {'print $3'})
+  if [ -z "$stashes" ]
   then
     echo 'Error: no stashes fetched or not in a Git repo.'
   fi
 
-  for stash in $(ls .git/refs/stashes)
+  for stash in $stashes
   do
     import "$stash"
   done

--- a/git-rstash
+++ b/git-rstash
@@ -38,10 +38,13 @@ function drop() {
   # core.abbrev configuration variable, it can be varied from machine to machine.
   stashCommit=$(git rev-parse stash@{$stashNum})
 
-  read -p "Really delete stash $stashNum (commit ${stashCommit:0:8}) from $remote? " answer
+  read -p "Really delete stash $stashNum (commit ${stashCommit:0:8}) from $remote and local refs/stashes? " answer
   if [ "$answer" == 'y' ]
   then
+    # remove from remote refs/stashes
     git push $remote :refs/stashes/$stashCommit
+    # remove from local refs/stashes
+    git update-ref -d refs/stashes/$stashCommit
   fi
 }
 

--- a/git-rstash
+++ b/git-rstash
@@ -16,7 +16,9 @@ function push() {
 
   echo "Pushing stash $1 to $remote."
 
-  git push $remote stash@{$1}:refs/stashes/$(git rev-parse --short stash@{$1})
+  # use full length of SHA, because length of --short SHA depends on
+  # core.abbrev configuration variable, it can be varied from machine to machine.
+  git push $remote stash@{$1}:refs/stashes/$(git rev-parse stash@{$1})
 }
 
 function fetch() {
@@ -32,9 +34,11 @@ function drop() {
   stashNum="$1"
   shift
   [ -z "$1" ] || remote="$1"
-  stashCommit=$(git rev-parse --short stash@{$stashNum})
+  # use full length of SHA, because length of --short SHA depends on
+  # core.abbrev configuration variable, it can be varied from machine to machine.
+  stashCommit=$(git rev-parse stash@{$stashNum})
 
-  read -p "Really delete stash $stashNum (commit $stashCommit) from $remote? " answer
+  read -p "Really delete stash $stashNum (commit ${stashCommit:0:8}) from $remote? " answer
   if [ "$answer" == 'y' ]
   then
     git push $remote :refs/stashes/$stashCommit


### PR DESCRIPTION
Hi @501st-alpha1 , 
I come from your [stackoverflow anwser](https://stackoverflow.com/a/61356308/1851492), and tries to use your script, it's a great job! But I've encountered some problems, so I try to fix those as below:

1. import-all() function support git submodule
2. fix import() function prompt error when its first time stash commit
2. push() and drop() function use full length SHA instead of short SHA (because I've encounter a problem of different short SHA length between machines)
3. Also delete local refs/stashes when drop() remote refs/stashes
4. add drop-all() function

 
